### PR TITLE
docs: README freshness update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ artwork/
 * All images must be the same size
 * Images must be publicly accessible (setting in Google Cloud Storage)
 
+
+## License
+
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## What's fixed

**Added missing License section** — the repo has a `LICENSE` file (MIT, Copyright 2018 Mat Ryer and Ashley McNamara) but the README didn't mention or link to it. Added a License section at the bottom.

## Flagged for manual attention

- The `BuildABit.Dev` URL referenced in the README appears to be offline (connection timeout). You may want to update or remove that link.
- The README has no install/setup/run instructions for the Go project — adding those would help contributors.